### PR TITLE
improve model init performance

### DIFF
--- a/bluenaas/services/single_neuron_simulation.py
+++ b/bluenaas/services/single_neuron_simulation.py
@@ -337,9 +337,6 @@ def stream_realtime_data(
                 logger.debug("Parent received queue_stop_event")
                 break
 
-            logger.info(
-                f"[R/S --> {record["label"]}/{record["recording_name"]}]",
-            )
             yield f"{json.dumps(queue_record_to_nexus_record(record, is_current_varying))}\n"
 
         logger.info(f"Realtime Simulation {request_id} completed")


### PR DESCRIPTION
The model init steps used to be executed in series, also some methods were re-fetching what has been already fetched in previous steps.

This change:
* Adds simple key-value cache for nexus entities (per request, not global).
* Parallelises fetching for the most of the model components.

I've also removed one logger call which was too verbose and possibly was a negative contributor to performance.

This change speeds up the model init process (on my machine) from **40+** to **13** seconds, similar change is expected in production.

Possible other improvements to consider later on:
* To add global cache for mod files (so that they can be retrieved by id).
* To add global cache for build artefacts (probably we can use a hash of the MOD file content as a key).