### PR TITLE
Make SynapseConfig model more permissive

### DIFF
--- a/app/domains/morphology.py
+++ b/app/domains/morphology.py
@@ -79,6 +79,10 @@ class SynapseConfig(BaseModel):
     @field_validator("formula", mode="before")
     @classmethod
     def validate_formula_depends_on_distribution(cls, value, info):
+        # TODO refactor to use formula field even for soma_synapse_count
+        if "target" in info.data and info.data.get("target") == SectionTarget.soma:
+            return value
+
         if "distribution" in info.data and info.data.get("distribution") == "formula":
             if not value or not isinstance(value, str):
                 raise ValueError('Formula must be a valid string when distribution is "formula".')


### PR DESCRIPTION
This is a quick fix to make validation pass for the synapse configs that are provided by the frontend (no need to validate formula if some is the target)

Long term - we should switch to using formula also for a constant number of synapses no matter which target is selected.