### PR TITLE
Update bluecellulab to v2.6.83 and libsonata v0.1.34 for SONATA parameter modification 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ api = [
     "sentry-sdk[fastapi]==2.53.0",
 ]
 worker = [
-    "bluecellulab==2.6.81",
+    "bluecellulab==2.6.83",
     "efel==5.7.20",
     "filelock==3.24.2",
     "ion-channel-builder",

--- a/uv.lock
+++ b/uv.lock
@@ -244,12 +244,13 @@ wheels = [
 
 [[package]]
 name = "bluecellulab"
-version = "2.6.81"
+version = "2.6.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluepysnap" },
     { name = "efel" },
     { name = "h5py" },
+    { name = "libsonata" },
     { name = "matplotlib" },
     { name = "neo" },
     { name = "networkx" },
@@ -261,9 +262,9 @@ dependencies = [
     { name = "seaborn" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/0e/33756fae2d302e487b0eab81f2065f7f05c15b0612ba223931040755e4b7/bluecellulab-2.6.81.tar.gz", hash = "sha256:3ddf6a10eab0a7d9e8255c0b9eb8b197b54c08afad84085cc9a7ed98017fbc57", size = 540713, upload-time = "2026-02-12T12:33:13.566Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/87/e8e8a4504ab1fcf5778f2f41d1994fd50849ad0946a10bb655515df5cb71/bluecellulab-2.6.83.tar.gz", hash = "sha256:39f174a6eb9a7cfd84dd9acd97989e09b65ea7d90cbbcf292e977316b68aee78", size = 546199, upload-time = "2026-03-09T08:03:43.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/13cebb7120dc11550e3a486ea26ef6bb02bcb857ab999f34fb2d2136cfbf/bluecellulab-2.6.81-py3-none-any.whl", hash = "sha256:ad10dfbfb2de2630c0a6cfec28258e3015bfe03ad574c0968e15286b3e708cc0", size = 162803, upload-time = "2026-02-12T12:33:12.354Z" },
+    { url = "https://files.pythonhosted.org/packages/49/da/34d6c7e215014cd938cbd16d2e45f8a6fc0adb6f3367c5493df8bea4d599/bluecellulab-2.6.83-py3-none-any.whl", hash = "sha256:ff07fdd4a11e8f40ca61863080eb06475ab7e4990b23ee167f0f807a6f8b8791", size = 168872, upload-time = "2026-03-09T08:03:41.54Z" },
 ]
 
 [[package]]
@@ -378,7 +379,7 @@ types = [
     { name = "types-requests", specifier = "==2.32.4.20250611" },
 ]
 worker = [
-    { name = "bluecellulab", specifier = "==2.6.81" },
+    { name = "bluecellulab", specifier = "==2.6.83" },
     { name = "efel", specifier = "==5.7.20" },
     { name = "filelock", specifier = "==3.24.2" },
     { name = "ion-channel-builder", git = "https://github.com/openbraininstitute/ion-channel-builder.git?tag=0.0.12" },
@@ -1117,7 +1118,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1746,17 +1746,16 @@ wheels = [
 
 [[package]]
 name = "libsonata"
-version = "0.1.31"
+version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/f1/e71c5a9088c5c7c080422f1b6991e91ec072874f546aef098db55af157cc/libsonata-0.1.31.tar.gz", hash = "sha256:4de060b4c613f706a28cb0ef267b8a05dfbe3cdc7d1f5e3694c0a1ba103e19cf", size = 1119244, upload-time = "2025-08-26T08:24:48.008Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/8f/b32a05fa124a711bb32d80d596392c361dad967254c4efc043f63d07c7b9/libsonata-0.1.34.tar.gz", hash = "sha256:a9015e42da17d08a473c47cb6104deb06d1280e065af956d00ac95894295c323", size = 1185106, upload-time = "2026-02-13T09:20:17.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/cd/5ade6b2af1cc00d32ea112aebec952708ae5db7ae7755d2434f7090ba000/libsonata-0.1.31-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1ca8d5ec144d913bd6769b35492395391a2a1e73ab0158fb8cdc4fecc2e2492c", size = 2089744, upload-time = "2025-08-26T08:24:10.48Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/79/84e82d25a6401ff34fc6e1d00d128d3b40b664304f2c8a4ee7607b1bd8a7/libsonata-0.1.31-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d1a3d9209426611cf7a313f25f276a61baec8d94039047fd480b4b8663cd0722", size = 1750533, upload-time = "2025-08-26T08:24:12.063Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/00/ef646065a525811a41251bfcf6a019d4fd1d94a8b3a4a9f07d8f2729682f/libsonata-0.1.31-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b17c00a161f03391947ea0ba6e1af02a4061ba08dbeb9853553da0bc69459e56", size = 2430796, upload-time = "2025-08-26T08:24:13.701Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c4/0bdc068757c9720b6231a7bde38331a5fcd41d316a7a4cc426c2ff6f48d4/libsonata-0.1.31-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:665f776ac58b6d2f8ad0f4d60d1d4f0e23666e24524f2dc0fb03134b064157fb", size = 2430618, upload-time = "2025-08-26T08:24:15.476Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f4/eca05a0028d2901d2e7bc3f99b1cad90c0c8569ed4ccb825739fbad99c11/libsonata-0.1.34-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70c52fac3e30fbc0f605c75422a339239a95acd3c6fcfd51e87167f6c25761c5", size = 2065323, upload-time = "2026-02-13T09:19:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/907f3cfd7d651f76705c5c69b61ee3f3126c8ce108f04d16239a5dd88050/libsonata-0.1.34-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f07e64ce2b7310f43541851e287012c11bc9f5caa3865e76b47dba879796274c", size = 1783528, upload-time = "2026-02-13T09:20:02.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/06/6e0f51926e25b35019411906a9ac1449bb6becf8654db9ffdb87609fa401/libsonata-0.1.34-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:666bb96a0fe04353e5046c3c37a495554cf31388754eb1ce9bce85967ef68e10", size = 2455684, upload-time = "2026-02-13T09:20:04.307Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
To test parameter modification:
- Updated bluecellulab v2.6.81 -> [v2.6.83](https://github.com/openbraininstitute/BlueCelluLab/releases/tag/2.6.83)
- Updated libsonata v0.1.31 -> v0.1.34 >> Required by bluecellulab v2.6.83 for parameter modifications.
