### PR TITLE
Update BlueCelluLab, efel, morphio version and numpy version upper limit

### DIFF
--- a/app/core/stimulation.py
+++ b/app/core/stimulation.py
@@ -171,6 +171,7 @@ def _add_single_synapse(
         )
         cell.connections[synid] = connection
     except Exception:
+        logger.exception(f"Failed to add synapse {synapse['id']} to the cell.")
         raise RuntimeError("Model not initialized")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ api = [
     "sentry-sdk[fastapi]==2.54.0",
 ]
 worker = [
-    "bluecellulab==2.6.91",
+    "bluecellulab==2.6.94",
     "efel==5.7.21",
     "filelock==3.25.0",
     "ion-channel-builder",
     "morphio==3.4.2",
     "numpy>=2.0.0,<2.5",
-    "obi-one==2026.4.3",
+    "obi-one==2026.4.4",
     "pynwb==3.1.3",
     "requests==2.32.5",
     "ultraliser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ api = [
 ]
 worker = [
     "bluecellulab==2.6.91",
-    "efel==5.7.20",
+    "efel==5.7.21",
     "filelock==3.25.0",
     "ion-channel-builder",
-    "morphio==3.4.1",
-    "numpy>=2.0.0,<2.4",
+    "morphio==3.4.2",
+    "numpy>=2.0.0,<2.5",
     "obi-one==2026.4.0",
     "pynwb==3.1.3",
     "requests==2.32.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ api = [
     "sentry-sdk[fastapi]==2.54.0",
 ]
 worker = [
-    "bluecellulab==2.6.87",
+    "bluecellulab==2.6.91",
     "efel==5.7.20",
     "filelock==3.25.0",
     "ion-channel-builder",

--- a/uv.lock
+++ b/uv.lock
@@ -244,7 +244,7 @@ wheels = [
 
 [[package]]
 name = "bluecellulab"
-version = "2.6.91"
+version = "2.6.94"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluepysnap" },
@@ -263,9 +263,9 @@ dependencies = [
     { name = "seaborn" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e5/30545307cfe9613398a7e9cdea526bfd38e65dde5a40ae517017779b29f8/bluecellulab-2.6.91.tar.gz", hash = "sha256:0ede2fff1cb2cfe0fdd90eb1605b47652ec2f806d6351263279951d4b0f620bd", size = 557607, upload-time = "2026-04-07T07:50:45.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/1a/e7ac070f6275fcfc1e2fc690056898f9eb0a212c9b7d4d7ea36278a361b4/bluecellulab-2.6.94.tar.gz", hash = "sha256:fb78397937e8381cc41938a32a63a58c4944d769e2a7e045d51fdc3691d613cb", size = 557909, upload-time = "2026-04-13T07:06:37.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/1b/920fc23d912e1f9814503b298a7cd87c65253883efeb399b57014776b45d/bluecellulab-2.6.91-py3-none-any.whl", hash = "sha256:35a86fe29eaff14f0ca1cd7ba8cab8917b4e8f4eb160e4e7e2ad339fac50e926", size = 182212, upload-time = "2026-04-07T07:50:43.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/be/f44acecab0928ab25338e8047ccd8ab9bb16a10a5d86bde185949d5e2692/bluecellulab-2.6.94-py3-none-any.whl", hash = "sha256:00b451633f6f8e070be426999d1cc518639d391ddacb7fa118815ce899657c3b", size = 182844, upload-time = "2026-04-13T07:06:36.214Z" },
 ]
 
 [[package]]
@@ -382,13 +382,13 @@ types = [
     { name = "types-requests", specifier = "==2.32.4.20260107" },
 ]
 worker = [
-    { name = "bluecellulab", specifier = "==2.6.91" },
+    { name = "bluecellulab", specifier = "==2.6.94" },
     { name = "efel", specifier = "==5.7.21" },
     { name = "filelock", specifier = "==3.25.0" },
     { name = "ion-channel-builder", git = "https://github.com/openbraininstitute/ion-channel-builder.git?tag=0.0.15" },
     { name = "morphio", specifier = "==3.4.2" },
     { name = "numpy", specifier = ">=2.0.0,<2.5" },
-    { name = "obi-one", specifier = "==2026.4.3" },
+    { name = "obi-one", specifier = "==2026.4.4" },
     { name = "pynwb", specifier = "==3.1.3" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "ultraliser" },
@@ -2314,7 +2314,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/99/7d/2d652962ee61c9e5a
 
 [[package]]
 name = "obi-one"
-version = "2026.4.3"
+version = "2026.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2353,7 +2353,7 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/cc/6ddd606def68674e60342260ad4ebaa42ded6f69d733a8bdf1887c7b5410/obi_one-2026.4.3.tar.gz", hash = "sha256:a69a3278e35526af8e86835e9a4b403e57a9a9cb107d087163bd33b8f2fa21ee", size = 13946824, upload-time = "2026-04-10T11:52:00.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/7ebe7b417a55b12c6c2863068a32503aa629c40a35edc209354e9656c247/obi_one-2026.4.4.tar.gz", hash = "sha256:d052a510cdd7f2b06886bce0667bbc4f35eb13ec005b3ec51d65330f7816a36a", size = 13949300, upload-time = "2026-04-10T12:29:39.629Z" }
 
 [[package]]
 name = "obp-accounting-sdk"

--- a/uv.lock
+++ b/uv.lock
@@ -383,11 +383,11 @@ types = [
 ]
 worker = [
     { name = "bluecellulab", specifier = "==2.6.91" },
-    { name = "efel", specifier = "==5.7.20" },
+    { name = "efel", specifier = "==5.7.21" },
     { name = "filelock", specifier = "==3.25.0" },
     { name = "ion-channel-builder", git = "https://github.com/openbraininstitute/ion-channel-builder.git?tag=0.0.15" },
-    { name = "morphio", specifier = "==3.4.1" },
-    { name = "numpy", specifier = ">=2.0.0,<2.4" },
+    { name = "morphio", specifier = "==3.4.2" },
+    { name = "numpy", specifier = ">=2.0.0,<2.5" },
     { name = "obi-one", specifier = "==2026.4.0" },
     { name = "pynwb", specifier = "==3.1.3" },
     { name = "requests", specifier = "==2.32.5" },
@@ -901,7 +901,7 @@ wheels = [
 
 [[package]]
 name = "efel"
-version = "5.7.20"
+version = "5.7.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "neo" },
@@ -910,11 +910,11 @@ dependencies = [
     { name = "scipy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/34/b81c91b1392adfcaf9de31a842694d780fafb44488a257b9303374664c6b/efel-5.7.20.tar.gz", hash = "sha256:0cfb56abf9fdb0199f3bcfc8dc0037cb86f06623b528cd9d896a25c1f9df4089", size = 140504, upload-time = "2025-10-21T12:55:11.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/0c/d86988ffa3e9e597f6a514245f492fb102334ccc057e897d32ccc28d9791/efel-5.7.21.tar.gz", hash = "sha256:934a014ef229231dcaa299b75e558f98b9597056070e3aa90f0db4c44a8f1c6a", size = 140879, upload-time = "2026-04-07T15:05:39.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/fa/ee67d9225d69725f124694daaa9a9a5c60a67ac0aa38f3c564221e5f1632/efel-5.7.20-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:473c753f62f3e82766e13639b6591e9e61e0653b554bb376ec1184f64888bda0", size = 260223, upload-time = "2025-10-21T12:55:00.834Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/00/6cdcb6ffc2e9195aac8d1d4602ceb8fd105c974226c7da4aa7715ebf48b2/efel-5.7.20-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce9ca3f0c831afe5ea1c17784c46b105b6beaf1f194d542d6e832c3e35eafe0d", size = 3018759, upload-time = "2025-10-21T12:55:02.155Z" },
-    { url = "https://files.pythonhosted.org/packages/97/e8/37d9708a4b39f4c923eb43d174fc3325bf11ba6dba6f0f9f523ffe0f4d5f/efel-5.7.20-cp312-cp312-win_amd64.whl", hash = "sha256:80507ab9984fb77d2c68e45c084e67aa0b042603e7a84c56896308329bebf44c", size = 237699, upload-time = "2025-10-21T12:55:04.552Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/13/e5868b9e09e72605039cf75dbcfa5bd0cd93580a22941a1076563aa63c0f/efel-5.7.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:65b17876329ae2a1f4ae30a6be49f3ab9f807cddd53e65a1e17dd78a5e837ea5", size = 253812, upload-time = "2026-04-07T15:05:22.108Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/47/0289a4f752bd78c56e6155fe88da466b5ea0fa364038b08497dfb280f6e4/efel-5.7.21-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25c49ab84d12be627b156dea4e139067826c3e6cfd0e2fc6f11b4a8a222fc6eb", size = 3019481, upload-time = "2026-04-07T15:05:23.454Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6f/ce9dbea3f78fe4dd444db41b79ddeac07dd21a2fd977d779c468bc5a3b1c/efel-5.7.21-cp312-cp312-win_amd64.whl", hash = "sha256:c975dba2025713845a43151e62e964205ac3bcc6ad4e884df86b95d7df3b186e", size = 238053, upload-time = "2026-04-07T15:05:25.226Z" },
 ]
 
 [[package]]
@@ -1943,18 +1943,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/11/a5/7855ee82afcb112fb
 
 [[package]]
 name = "morphio"
-version = "3.4.1"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/6e/46d00838b39fffec4f8e096e4b1ad65184c02027cf8a21bfa89b450bf19a/morphio-3.4.1.tar.gz", hash = "sha256:18038eec9254397663c06c029f4cdd72fa904d97a671b4eb23ad273b80c0b14b", size = 678889, upload-time = "2026-03-04T15:17:13.952Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/7f/ae58db0e19ceaf3b4e8cc168678a0cc0ae64ed9bea9211860108a24a9d66/morphio-3.4.2.tar.gz", hash = "sha256:4521b01dd8de8ff98b44341318cee44d75552dfd58b95a0e82ebfffe653b88f8", size = 690093, upload-time = "2026-03-25T13:00:50.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/0e/11dd53123051e15a0839274671cbc0b8d76a40bc8c8160077da7c8583160/morphio-3.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a796ca7482735e9c2a91ce4640e2048c26b13b1a8b87724e0131ff1f0d463d07", size = 2083061, upload-time = "2026-03-04T15:16:39.683Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/71/a6734e4c215d0c2a326b3b851555a6f09ec04ef5e25da8526edecdcabc63/morphio-3.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fac27ad48de70a6c9e2621c69987aad3f2f41a27ad8b276e9bd490e6ad9a902a", size = 1779188, upload-time = "2026-03-04T15:16:41.733Z" },
-    { url = "https://files.pythonhosted.org/packages/81/b3/11c6b2ce138a5848c4909f46fbdc9f1eee0634fc9427bcab6ab72217301c/morphio-3.4.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:22225c3897199e8db935513337eedad55a7d3a8f1826adea400bdb807883da8e", size = 2228835, upload-time = "2026-03-04T15:16:43.834Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/d6/7407aaa0ebaea4c0f23aa29947fe8120914b6b0a4f3db1c91aa940037ef4/morphio-3.4.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:06e774f6dcbc1dde99402cf6ab032de8365004bac1d124653d34f7dd1a272fcd", size = 2494693, upload-time = "2026-03-04T15:16:45.344Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/f1/8cc271e10e80f46cd978ca4d80f90daa6e3659b22936ba510b2aa6fd85ff/morphio-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:d1d96d2e3f8a3fead7315b0ef7774ccb12ef29df2d147194d9b3531aea4ff69f", size = 624573, upload-time = "2026-03-04T15:16:46.845Z" },
+    { url = "https://files.pythonhosted.org/packages/26/f0/232b9552d1894cd47221a56ba1a1c9eac286591686b8cadaead5ecbc80ab/morphio-3.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7dd40908d16e8b7bab5d747e4083137f55d1b0ecaf17b6f28b223b59727d45da", size = 2084492, upload-time = "2026-03-25T13:00:17.63Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/556b5f52eda9ebd2d705261d10aec016b45b0d8d0c60c847fe652f28dc08/morphio-3.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a134d12b64d85d78ebdad29b95848c673320a8331fdb62cb754a84f96a00517", size = 1780933, upload-time = "2026-03-25T13:00:19.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/eb/ba41bf7afa3de6c467307f20d69361aff7eb9f08b679ae03dee334b0b87c/morphio-3.4.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c625a918571d3a72fbbfbee01fb74112bc5a05ea5d374f9200dbd1a179393490", size = 2231502, upload-time = "2026-03-25T13:00:20.822Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b7/b82c4e3c7d7e269ca78e1b2c017b1b8da4fd8161b7e3fc2b495ee91507ab/morphio-3.4.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:19b9b759796ff60e06eb92e28e2e52fb0653eb8872d6c26a6438beec7e1e6744", size = 2498053, upload-time = "2026-03-25T13:00:22.707Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8a/4d2766d5d5466f67e2316af7ea47e087f77fca69f3cfd48a6a79d3916961/morphio-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:d58adc5aeaa0ce2ce16e5e7c295b8d9849eeb367b8ad2386442b5ed1a75561a6", size = 626513, upload-time = "2026-03-25T13:00:24.397Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -244,7 +244,7 @@ wheels = [
 
 [[package]]
 name = "bluecellulab"
-version = "2.6.87"
+version = "2.6.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bluepysnap" },
@@ -252,6 +252,7 @@ dependencies = [
     { name = "h5py" },
     { name = "libsonata" },
     { name = "matplotlib" },
+    { name = "morphio" },
     { name = "neo" },
     { name = "networkx" },
     { name = "neuron" },
@@ -262,9 +263,9 @@ dependencies = [
     { name = "seaborn" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/b3/7a92f8efa0067b1c320a2560f9c746dd195f8dca4ac449b288a1d01c04f6/bluecellulab-2.6.87.tar.gz", hash = "sha256:7d00f3ad38b1d16043ca77e029984c9d6a282ec2772f7c9eac840c91e6664c08", size = 548055, upload-time = "2026-03-12T16:28:05.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e5/30545307cfe9613398a7e9cdea526bfd38e65dde5a40ae517017779b29f8/bluecellulab-2.6.91.tar.gz", hash = "sha256:0ede2fff1cb2cfe0fdd90eb1605b47652ec2f806d6351263279951d4b0f620bd", size = 557607, upload-time = "2026-04-07T07:50:45.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/19/5859d4f1653ec769a056be721b4c511213d0690e3b02c46535d51ad9d087/bluecellulab-2.6.87-py3-none-any.whl", hash = "sha256:45ac9de4f36a0a1289f469584b9a3a7a9c8df5395057e6e9012fe4542c38b166", size = 170747, upload-time = "2026-03-12T16:28:03.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1b/920fc23d912e1f9814503b298a7cd87c65253883efeb399b57014776b45d/bluecellulab-2.6.91-py3-none-any.whl", hash = "sha256:35a86fe29eaff14f0ca1cd7ba8cab8917b4e8f4eb160e4e7e2ad339fac50e926", size = 182212, upload-time = "2026-04-07T07:50:43.259Z" },
 ]
 
 [[package]]
@@ -381,7 +382,7 @@ types = [
     { name = "types-requests", specifier = "==2.32.4.20260107" },
 ]
 worker = [
-    { name = "bluecellulab", specifier = "==2.6.87" },
+    { name = "bluecellulab", specifier = "==2.6.91" },
     { name = "efel", specifier = "==5.7.20" },
     { name = "filelock", specifier = "==3.25.0" },
     { name = "ion-channel-builder", git = "https://github.com/openbraininstitute/ion-channel-builder.git?tag=0.0.15" },
@@ -1120,7 +1121,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },


### PR DESCRIPTION
- Required for this [issue](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/175).
- Updating BlueCelluLab to 2.6.94 in pyproject.toml
- obi-one to 2026.4.4
- eFEL bump to 5.7.21: https://github.com/openbraininstitute/eFEL/releases/tag/5.7.21
- morphio bump to 3.4.2 https://github.com/openbraininstitute/MorphIO/releases/tag/v3.4.2
- Update numpy version upper bound <2.5 [similar](https://github.com/openbraininstitute/BlueCelluLab/blob/50ae53af0349c069085f389d574acabc2e7184be/pyproject.toml#L33) to bluecellulab. Numpy's latest [version](https://github.com/numpy/numpy/releases/tag/v2.4.4) is 2.4.4.
- Updated uv-lock via `uv sync`.