### PR TITLE
Ignore directory removal errors, log warnings instead

### DIFF
--- a/app/infrastructure/storage/__init__.py
+++ b/app/infrastructure/storage/__init__.py
@@ -1,6 +1,7 @@
 import shutil
 from pathlib import Path
 from uuid import uuid5, UUID, NAMESPACE_URL
+from loguru import logger
 
 from app.config.settings import settings
 
@@ -25,8 +26,14 @@ def copy_file_content(source_file: Path, target_file: Path):
 
 
 def rm_dir(path: Path) -> None:
+    """Remove directory if exists, log warning if fails."""
     if path.exists():
-        shutil.rmtree(path)
+        shutil.rmtree(
+            path,
+            onexc=lambda func, path, exc_info: logger.warning(
+                f"Failed: {func.__name__} on {path}: {exc_info}"
+            ),
+        )
 
 
 def ensure_dir(path: Path) -> Path:


### PR DESCRIPTION
It turns out Neuron keeps `x86_64/libnrnmech.so` open until the (Python caller) process is alive.
In combination with NFS (AWS EFS), where an open file when unlinked is getting renamed this is causing a failure to remove the model directory, when called from the same process.

For now, the workaround is just to ignore exceptions when trying to remove the directory. Anyway it's going to be eventually cleaned up when the cache is getting removed.

A proper solution would be to run neuron model init in a forked process, but given that the service is going to be retired - the refactoring is not worth the effort.