### PR TITLE
Fix MPI error propagation by calling h.quit() only on success

### DIFF
--- a/app/core/circuit/simulation-mpi-entrypoint.py
+++ b/app/core/circuit/simulation-mpi-entrypoint.py
@@ -244,15 +244,16 @@ def run_bluecellulab(
     except Exception as e:
         logger.error(f"Rank {rank} failed: {str(e)}", exc_info=True)
         raise
-    finally:
-        try:
-            logger.info(f"Rank {rank}: Cleaning up...")
-            pc.barrier()
-            h.quit()
-            if rank == 0:
-                logger.info("All ranks completed. Simulation finished.")
-        except Exception as e:
-            logger.error(f"Error during cleanup in rank {rank}: {str(e)}")
+
+    try:
+        # Ensure proper cleanup for successful runs
+        logger.info(f"Rank {rank}: Cleaning up...")
+        pc.barrier()
+        h.quit()
+        if rank == 0:
+            logger.info("All ranks completed. Simulation finished.")
+    except Exception as e:
+        logger.error(f"Error during cleanup in rank {rank}: {str(e)}")
 
 
 def main():


### PR DESCRIPTION
It turns out the [Add NWB current reporting](https://github.com/openbraininstitute/Bluenaas/pull/124) introduced a regression which broke error propagation from circuit simulator script via MPI to the caller process.

This PR reverts corresponding code part.