### PR TITLE
Remove custom parameter add_replay from simulation-mpi-entrypoint.py

### DIFF
--- a/app/core/circuit/simulation-mpi-entrypoint.py
+++ b/app/core/circuit/simulation-mpi-entrypoint.py
@@ -97,7 +97,6 @@ def get_instantiate_gids_params(
     if "inputs" in simulation_config_data:
         for input_def in simulation_config_data["inputs"].values():
             if input_def.get("module") == "synapse_replay":
-                params["add_replay"] = True
                 params["add_synapses"] = True
                 break
 


### PR DESCRIPTION
- Remove custom parameter add_replay from simulation-mpi-entrypoint.py
- It is set to False by default in bluecellulab, and we do not need to change it to True
- Should make the Poisson stimuli work.