### PR TITLE
MOD compilation cache

### DIFF
--- a/app/core/circuit/circuit.py
+++ b/app/core/circuit/circuit.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
 from uuid import UUID
@@ -60,16 +59,9 @@ class CircuitBase(ABC):
 
     def _compile_mod_files(self):
         """Compile MOD files"""
-        mech_path = self.path / CIRCUIT_MOD_DIR
-        if not mech_path.is_dir():
-            err_msg = f"'{CIRCUIT_MOD_DIR}' folder not found under {self.path}"
-            raise FileNotFoundError(err_msg)
+        from app.core.compilation_cache import compile_with_cache
 
-        # TODO: add additional arg to ensure custom mod files compilation
-        # Check with Darshan
-        cmd = ["nrnivmodl", "-incflags", "-DDISABLE_REPORTINGLIB", CIRCUIT_MOD_DIR]
-        compilation_output = subprocess.check_output(cmd, cwd=self.path)
-        logger.debug(compilation_output.decode())
+        compile_with_cache(self.path, CIRCUIT_MOD_DIR)
 
     def init(self):
         """Fetch circuit assets and compile MOD files"""

--- a/app/core/compilation_cache.py
+++ b/app/core/compilation_cache.py
@@ -1,0 +1,83 @@
+"""Content-addressable compilation cache for nrnivmodl MOD files."""
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+
+from filelock import FileLock
+from loguru import logger
+
+from app.config.settings import settings
+from app.constants import READY_MARKER_FILE_NAME
+
+
+def compute_mod_hash(mod_dir: Path) -> str:
+    """Compute a deterministic SHA-256 hash of all .mod files in a directory."""
+    mod_files = sorted(mod_dir.glob("*.mod"))
+    if not mod_files:
+        raise FileNotFoundError(f"No .mod files found in {mod_dir}")
+
+    hasher = hashlib.sha256()
+    for mod_file in mod_files:
+        hasher.update(mod_file.name.encode())
+        hasher.update(b"\0")
+        hasher.update(mod_file.read_bytes())
+    return hasher.hexdigest()
+
+
+def get_compilation_cache_path(mod_hash: str) -> Path:
+    """Return the cache directory path for a given hash."""
+    path = settings.STORAGE_PATH / "compilation-cache" / mod_hash[:2] / mod_hash[2:4] / mod_hash[4:]
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def compile_with_cache(model_path: Path, mod_dir_name: str) -> None:
+    """Compile MOD files using a content-addressable cache.
+
+    1. If model already has compiled output, return early.
+    2. Hash MOD file contents to get a cache key.
+    3. On cache hit, copy compiled artifacts to model directory.
+    4. On cache miss, compile, store in cache, then copy to model directory.
+    """
+    compiled_path = model_path / "x86_64"
+    if compiled_path.is_dir():
+        logger.debug("Found already compiled mechanisms")
+        return
+
+    mod_dir = model_path / mod_dir_name
+    if not mod_dir.is_dir():
+        raise FileNotFoundError(f"'{mod_dir_name}' folder not found under {model_path}")
+
+    mod_hash = compute_mod_hash(mod_dir)
+    cache_path = get_compilation_cache_path(mod_hash)
+    cache_ready = cache_path / READY_MARKER_FILE_NAME
+
+    if cache_ready.exists():
+        logger.debug(f"Compilation cache hit for hash {mod_hash[:12]}")
+        shutil.copytree(cache_path / "x86_64", compiled_path)
+        return
+
+    lock = FileLock(cache_path / "dir.lock")
+
+    with lock.acquire(timeout=5 * 60):
+        if cache_ready.exists():
+            logger.debug(f"Compilation cache hit (after lock) for hash {mod_hash[:12]}")
+            shutil.copytree(cache_path / "x86_64", compiled_path)
+            return
+
+        logger.info(f"Compilation cache miss for hash {mod_hash[:12]}, compiling")
+
+        cache_mod_dir = cache_path / mod_dir_name
+        if cache_mod_dir.exists():
+            shutil.rmtree(cache_mod_dir)
+        shutil.copytree(mod_dir, cache_mod_dir)
+
+        cmd = ["nrnivmodl", "-incflags", "-DDISABLE_REPORTINGLIB", mod_dir_name]
+        compilation_output = subprocess.check_output(cmd, cwd=cache_path, text=True)
+        logger.debug(compilation_output)
+
+        cache_ready.touch()
+
+    shutil.copytree(cache_path / "x86_64", compiled_path)

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -76,7 +76,7 @@ class Model:
         )
 
         single_neuron = SingleNeuron(self.model_id, client=client)
-        single_neuron.init()
+        single_neuron.init_files()
 
         self.threshold_current = single_neuron.threshold_current
 

--- a/app/core/single_neuron/single_neuron.py
+++ b/app/core/single_neuron/single_neuron.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from os import chdir
-import subprocess
 from pathlib import Path
 from typing import Any, cast
 from uuid import UUID
@@ -23,6 +22,7 @@ from app.constants import (
     SINGLE_NEURON_MOD_DIR,
     SINGLE_NEURON_MORPHOLOGY_DIR,
 )
+from app.core.compilation_cache import compile_with_cache
 from app.core.exceptions import SingleNeuronInitError
 from app.infrastructure.storage import (
     copy_file_content,
@@ -66,26 +66,6 @@ class SingleNeuronBase(ABC):
             self.path / SINGLE_NEURON_MOD_DIR / "ProbAMPANMDA_EMS.mod",
         )
 
-    def _compile_mod_files(self):
-        """Compile MOD files"""
-        mech_path = self.path / SINGLE_NEURON_MOD_DIR
-        if not mech_path.is_dir():
-            err_msg = f"'{SINGLE_NEURON_MOD_DIR}' folder not found under {self.path}"
-            raise FileNotFoundError(err_msg)
-
-        cmd = [
-            "nrnivmodl",
-            "-incflags",
-            "-DDISABLE_REPORTINGLIB",
-            SINGLE_NEURON_MOD_DIR,
-        ]
-        compilation_output = subprocess.check_output(
-            cmd,
-            cwd=self.path,
-            text=True,
-        )
-        logger.debug(compilation_output)
-
     def _init_model_files(self):
         ready_marker = self.path / READY_MARKER_FILE_NAME
 
@@ -102,7 +82,7 @@ class SingleNeuronBase(ABC):
 
             self._fetch_assets()
             self._add_syn_mod_files()
-            self._compile_mod_files()
+            compile_with_cache(self.path, SINGLE_NEURON_MOD_DIR)
             ready_marker.touch()
 
     def _init_bcl_cell(self):
@@ -131,6 +111,13 @@ class SingleNeuronBase(ABC):
         )
 
         logger.debug("BCL Cell initialized")
+
+    def init_files(self):
+        """Fetch model assets and compile MOD files (no Cell creation)."""
+        try:
+            self._init_model_files()
+        except Exception:
+            raise SingleNeuronInitError()
 
     def init(self):
         """Fetch model assets, compile MOD files and initialize BlueCelluLab Cell"""

--- a/app/core/single_neuron/single_neuron.py
+++ b/app/core/single_neuron/single_neuron.py
@@ -166,7 +166,9 @@ class SingleNeuron(SingleNeuronBase):
         assert self.metadata.id is not None
 
         logger.debug(f"Fetching single neuron model {self.model_id}")
-        download_memodel(self.client, memodel=self.metadata, output_dir=str(self.path))
+        download_memodel(
+            self.client, memodel=self.metadata, output_dir=str(self.path), max_concurrent=8
+        )
 
     @property
     def holding_current(self) -> float:

--- a/app/infrastructure/storage/__init__.py
+++ b/app/infrastructure/storage/__init__.py
@@ -110,3 +110,7 @@ def clear_mesh_cache() -> None:
 
 def clear_ion_channel_cache() -> None:
     rm_dir(settings.STORAGE_PATH / "ion-channel")
+
+
+def clear_compilation_cache() -> None:
+    rm_dir(settings.STORAGE_PATH / "compilation-cache")

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.infrastructure.kc.auth import AdminAuthDep
 from app.infrastructure.storage import (
     clear_circuit_cache,
+    clear_compilation_cache,
     clear_ion_channel_cache,
     clear_mesh_cache,
     clear_single_neuron_cache,
@@ -33,3 +34,9 @@ async def clear_mesh_storage(_: AdminAuthDep):
 async def clear_ion_channel_storage(_: AdminAuthDep):
     clear_ion_channel_cache()
     return {"message": "Ion channel cache cleared successfully"}
+
+
+@router.delete("/cache/compilation", tags=["admin"])
+async def clear_compilation_storage(_: AdminAuthDep):
+    clear_compilation_cache()
+    return {"message": "Compilation cache cleared successfully"}

--- a/app/utils/util.py
+++ b/app/utils/util.py
@@ -2,7 +2,6 @@
 
 import json
 import re
-import subprocess
 from typing import Any
 
 import numpy as np
@@ -31,21 +30,9 @@ def is_spine(sec_name):
 
 def compile_mechanisms(model_path):
     """Compile model mechanisms."""
-    # Bail out if the mechanisms are already compiled
-    compiled_path = model_path / "x86_64"
-    if compiled_path.is_dir():
-        L.debug("Found already compiled mechanisms")
-        return
+    from app.core.compilation_cache import compile_with_cache
 
-    mech_path = model_path / SINGLE_NEURON_MOD_DIR
-    if not mech_path.is_dir():
-        raise Exception(
-            f"Folder not found! Expecting '{SINGLE_NEURON_MOD_DIR}' folder in the model!"
-        )
-    else:
-        cmd = ["nrnivmodl", "-incflags", "-DDISABLE_REPORTINGLIB", SINGLE_NEURON_MOD_DIR]
-        compilation_output = subprocess.check_output(cmd, cwd=model_path)
-        L.info(compilation_output.decode())
+    compile_with_cache(model_path, SINGLE_NEURON_MOD_DIR)
 
 
 def get_sec_name(template_name, sec):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = "==3.12.13"
 
 dependencies = [
-    "entitysdk==0.13.3",
+    "entitysdk==0.14.1",
     "loguru==0.7.3",
     "msgpack>=1.1.2",
     "nanoid>=2.0.0",

--- a/tests/core/test_compilation_cache.py
+++ b/tests/core/test_compilation_cache.py
@@ -1,0 +1,145 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+os.environ.setdefault("ACCOUNTING_DISABLED", "1")
+
+from app.core.compilation_cache import compile_with_cache, compute_mod_hash
+
+
+class TestComputeModHash(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.mod_dir = self.tmpdir / "mechanisms"
+        self.mod_dir.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_deterministic_hash(self):
+        (self.mod_dir / "A.mod").write_text("content A")
+        (self.mod_dir / "B.mod").write_text("content B")
+
+        hash1 = compute_mod_hash(self.mod_dir)
+        hash2 = compute_mod_hash(self.mod_dir)
+        self.assertEqual(hash1, hash2)
+
+    def test_different_content_different_hash(self):
+        (self.mod_dir / "A.mod").write_text("content A")
+        hash1 = compute_mod_hash(self.mod_dir)
+
+        (self.mod_dir / "A.mod").write_text("content B")
+        hash2 = compute_mod_hash(self.mod_dir)
+
+        self.assertNotEqual(hash1, hash2)
+
+    def test_different_filenames_different_hash(self):
+        (self.mod_dir / "A.mod").write_text("same content")
+        hash1 = compute_mod_hash(self.mod_dir)
+
+        (self.mod_dir / "A.mod").unlink()
+        (self.mod_dir / "B.mod").write_text("same content")
+        hash2 = compute_mod_hash(self.mod_dir)
+
+        self.assertNotEqual(hash1, hash2)
+
+    def test_order_independent(self):
+        """Hash should be the same regardless of file creation order."""
+        (self.mod_dir / "B.mod").write_text("content B")
+        (self.mod_dir / "A.mod").write_text("content A")
+        hash1 = compute_mod_hash(self.mod_dir)
+
+        shutil.rmtree(self.mod_dir)
+        self.mod_dir.mkdir()
+        (self.mod_dir / "A.mod").write_text("content A")
+        (self.mod_dir / "B.mod").write_text("content B")
+        hash2 = compute_mod_hash(self.mod_dir)
+
+        self.assertEqual(hash1, hash2)
+
+    def test_no_mod_files_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            compute_mod_hash(self.mod_dir)
+
+
+class TestCompileWithCache(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.storage_path = self.tmpdir / "storage"
+        self.storage_path.mkdir()
+
+        self.model_path = self.tmpdir / "model"
+        self.model_path.mkdir()
+        self.mod_dir = self.model_path / "mechanisms"
+        self.mod_dir.mkdir()
+        (self.mod_dir / "test.mod").write_text("NEURON { SUFFIX test }")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_skips_if_already_compiled(self):
+        compiled = self.model_path / "x86_64"
+        compiled.mkdir()
+
+        with patch("app.core.compilation_cache.subprocess") as mock_sub:
+            compile_with_cache(self.model_path, "mechanisms")
+            mock_sub.check_output.assert_not_called()
+
+    @patch("app.core.compilation_cache.settings")
+    @patch("app.core.compilation_cache.subprocess")
+    def test_cache_miss_compiles_and_caches(self, mock_sub, mock_settings):
+        mock_settings.STORAGE_PATH = self.storage_path
+
+        def fake_compile(cmd, cwd, text=False):
+            (cwd / "x86_64" / "lib").mkdir(parents=True)
+            (cwd / "x86_64" / "lib" / "nrnmech.so").write_text("compiled")
+            return "compilation output"
+
+        mock_sub.check_output.side_effect = fake_compile
+
+        compile_with_cache(self.model_path, "mechanisms")
+
+        mock_sub.check_output.assert_called_once()
+        self.assertTrue((self.model_path / "x86_64" / "lib" / "nrnmech.so").exists())
+
+        # Verify cache was populated
+        cache_base = self.storage_path / "compilation-cache"
+        self.assertTrue(cache_base.exists())
+
+    @patch("app.core.compilation_cache.settings")
+    @patch("app.core.compilation_cache.subprocess")
+    def test_cache_hit_skips_compilation(self, mock_sub, mock_settings):
+        mock_settings.STORAGE_PATH = self.storage_path
+
+        def fake_compile(cmd, cwd, text=False):
+            (cwd / "x86_64" / "lib").mkdir(parents=True)
+            (cwd / "x86_64" / "lib" / "nrnmech.so").write_text("compiled")
+            return "compilation output"
+
+        mock_sub.check_output.side_effect = fake_compile
+
+        # First call: cache miss, compiles
+        compile_with_cache(self.model_path, "mechanisms")
+        self.assertEqual(mock_sub.check_output.call_count, 1)
+
+        # Remove compiled output from model path to simulate a second model
+        shutil.rmtree(self.model_path / "x86_64")
+
+        # Second call: cache hit, should not compile again
+        compile_with_cache(self.model_path, "mechanisms")
+        self.assertEqual(mock_sub.check_output.call_count, 1)  # Still 1
+        self.assertTrue((self.model_path / "x86_64" / "lib" / "nrnmech.so").exists())
+
+    def test_missing_mod_dir_raises(self):
+        empty_path = self.tmpdir / "empty"
+        empty_path.mkdir()
+
+        with self.assertRaises(FileNotFoundError):
+            compile_with_cache(empty_path, "mechanisms")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infrastructure/storage/test_cache.py
+++ b/tests/infrastructure/storage/test_cache.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+os.environ.setdefault("ACCOUNTING_DISABLED", "1")
+
+from app.infrastructure.storage import (
+    clear_circuit_cache,
+    clear_compilation_cache,
+    clear_ion_channel_cache,
+    clear_mesh_cache,
+    clear_single_neuron_cache,
+)
+
+
+class TestClearCache(unittest.TestCase):
+    @patch("app.infrastructure.storage.settings")
+    @patch("app.infrastructure.storage.rm_dir")
+    def test_clear_circuit_cache(self, mock_rm_dir, mock_settings):
+        mock_settings.STORAGE_PATH = Path("/test/storage")
+        clear_circuit_cache()
+        mock_rm_dir.assert_called_once_with(Path("/test/storage/circuit"))
+
+    @patch("app.infrastructure.storage.settings")
+    @patch("app.infrastructure.storage.rm_dir")
+    def test_clear_single_neuron_cache(self, mock_rm_dir, mock_settings):
+        mock_settings.STORAGE_PATH = Path("/test/storage")
+        clear_single_neuron_cache()
+        mock_rm_dir.assert_called_once_with(Path("/test/storage/single-neuron"))
+
+    @patch("app.infrastructure.storage.settings")
+    @patch("app.infrastructure.storage.rm_dir")
+    def test_clear_mesh_cache(self, mock_rm_dir, mock_settings):
+        mock_settings.STORAGE_PATH = Path("/test/storage")
+        clear_mesh_cache()
+        mock_rm_dir.assert_called_once_with(Path("/test/storage/mesh"))
+
+    @patch("app.infrastructure.storage.settings")
+    @patch("app.infrastructure.storage.rm_dir")
+    def test_clear_ion_channel_cache(self, mock_rm_dir, mock_settings):
+        mock_settings.STORAGE_PATH = Path("/test/storage")
+        clear_ion_channel_cache()
+        mock_rm_dir.assert_called_once_with(Path("/test/storage/ion-channel"))
+
+    @patch("app.infrastructure.storage.settings")
+    @patch("app.infrastructure.storage.rm_dir")
+    def test_clear_compilation_cache(self, mock_rm_dir, mock_settings):
+        mock_settings.STORAGE_PATH = Path("/test/storage")
+        clear_compilation_cache()
+        mock_rm_dir.assert_called_once_with(Path("/test/storage/compilation-cache"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/routes/test_admin.py
+++ b/tests/routes/test_admin.py
@@ -106,6 +106,26 @@ class TestAdminRoutes(unittest.TestCase):
         self.assertEqual(response.json(), {"message": "Ion channel cache cleared successfully"})
         mock_clear_cache.assert_called_once()
 
+    @patch("app.routes.admin.clear_compilation_cache")
+    @patch("app.infrastructure.kc.auth.kc_auth")
+    def test_clear_compilation_cache_success(self, mock_kc_auth, mock_clear_cache):
+        mock_kc_auth.decode_token.return_value = {
+            "exp": 1234567890,
+            "iss": "http://localhost:9090/",
+            "sub": "admin-123",
+            "preferred_username": "admin",
+            "email": "admin@example.com",
+        }
+        mock_kc_auth.userinfo.return_value = {"groups": ["/service/small-scale-simulator/admin"]}
+
+        response = self.client.delete(
+            "/admin/cache/compilation", headers={"Authorization": "Bearer admin-token"}
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json(), {"message": "Compilation cache cleared successfully"})
+        mock_clear_cache.assert_called_once()
+
     @patch("app.app.logger")
     @patch("app.infrastructure.kc.auth.kc_auth")
     def test_clear_cache_unauthorized(self, mock_kc_auth, mock_logger):

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ worker = [
 
 [package.metadata]
 requires-dist = [
-    { name = "entitysdk", specifier = "==0.13.3" },
+    { name = "entitysdk", specifier = "==0.14.1" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -932,14 +932,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.13.3"
+version = "0.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/54/fb4fe933ad003de7228cee3b4feb04a333d5f8c80096f72d0d582d78216e/entitysdk-0.13.3.tar.gz", hash = "sha256:4725208bc1868586e6e65bfdae41ff05d448e4b0e3d2902fcba88a20cb60ac38", size = 80656, upload-time = "2026-04-10T11:33:59.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/b8/4a7ebfad655a93b0513a5b7846bde29dd2dddc2f09fd02fc0d119b5bcc99/entitysdk-0.14.1.tar.gz", hash = "sha256:7c64b29b7e2bd6ae8e736e8588713906bf2753ae21b5554a312d0173af3ee204", size = 81684, upload-time = "2026-04-16T11:43:45.668Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
## Summary

  Introduces a content-addressable compilation cache for `nrnivmodl` MOD files. Multiple MEModels often share the same EModel and thus identical MOD files — this avoids redundant compilations by caching the `x86_64/` output keyed on a SHA-256 hash of MOD file contents.

  ## Changes

  - **`app/core/compilation_cache.py`** (new) — `compute_mod_hash()` hashes all `.mod` files deterministically; `compile_with_cache()` implements check → lock → compile-or-copy flow with `FileLock` for concurrent worker safety
  - **Unified compilation** — replaced three separate `nrnivmodl` subprocess calls (`single_neuron.py`, `circuit.py`, `util.py`) with `compile_with_cache()`
  - **`SingleNeuronBase.init_files()`** — new method for file-only initialization (no Cell creation), used by `Model._init_model`
  - **Admin endpoint** — `DELETE /admin/cache/compilation` to clear the compilation cache
  - **Cache storage** — `compilation-cache/{hash[:2]}/{hash[2:4]}/{hash[4:]}/` under `STORAGE_PATH`

  ## Cache flow

  ```
  1. Check if x86_64/ already exists in model dir → skip
  2. Hash MOD files → lookup in cache
  3. Cache hit  → copytree x86_64/ from cache to model dir
  4. Cache miss → compile in cache dir, mark .ready, copytree to model dir
  ```

  ## Tests

  - `tests/core/test_compilation_cache.py` — hash determinism, ordering, cache hit/miss, error cases
  - `tests/infrastructure/storage/test_cache.py` — all cache-clearing functions
  - `tests/routes/test_admin.py` — new admin endpoint
  
Relates to [Caching me-models to prevent 30 sec. wait time in Simulate (or Build) Workflows when model is used the first time](https://github.com/openbraininstitute/prod-build-emodel/issues/173).