### PR TITLE
Raise NEURON NSTACK/NFRAME in worker image

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -83,6 +83,10 @@ ENV PYTHONPATH="/app:$PYTHONPATH"
 # TODO: Double check if this is needed
 ENV HDF5_USE_FILE_LOCKING=FALSE
 
+# Skeletonized morphologies are more complex and require higher values for the params below
+# compared to the NEURON defaults
+ENV NEURON_MODULE_OPTIONS="-NSTACK 100000 -NFRAME 10000"
+
 COPY --chown=app:app --from=builder /app/.venv/ .venv
 COPY --chown=app:app docker-worker-cmd.sh ./docker-cmd.sh
 COPY --chown=app:app app/ ./app


### PR DESCRIPTION
## What

Set `NEURON_MODULE_OPTIONS="-NSTACK 100000 -NFRAME 10000"` as an `ENV` in the run stage of `Dockerfile.worker`.

## Why

NEURON is embedded in the worker via `import neuron` (through BlueCelluLab), so `-NSTACK`/`-NFRAME` can't be passed on a command line the way they would be to `nrniv`/`special`. NEURON (9.0.1) reads these launch options from the `NEURON_MODULE_OPTIONS` environment variable at import time, so setting it in the image is the reliable single source of truth — present in both local compose and prod, and guaranteed set before NEURON is imported.

Skeletonized morphologies are more complex and need higher stack/frame sizes than the NEURON defaults.

## Notes

- Worker-only: the API just validates and enqueues, so it does not need this.
- Requires rebuilding the worker image to take effect. Verify at runtime with `docker compose exec worker printenv NEURON_MODULE_OPTIONS`.
- The difference in the memory consumption due to the change is negligible.