### PR TITLE
Support passive ME-models without MOD files in circuit simulations

### DIFF
--- a/app/core/circuit/circuit.py
+++ b/app/core/circuit/circuit.py
@@ -149,7 +149,9 @@ class MEModelCircuit(CircuitBase):
         assert self.metadata.id is not None
         stage_sonata_from_memodel(self.client, memodel=self.metadata, output_dir=self.path)
         mod_path = self.path / CIRCUIT_MEMODEL_MOD_DIR
-        mod_path.rename(self.path / CIRCUIT_MOD_DIR)
+        # Passive ME-models ship no mechanisms, so the folder may be absent.
+        if mod_path.is_dir():
+            mod_path.rename(self.path / CIRCUIT_MOD_DIR)
 
 
 class IonChannelModelCircuit(CircuitBase):

--- a/app/core/circuit/simulation-mpi-entrypoint.py
+++ b/app/core/circuit/simulation-mpi-entrypoint.py
@@ -116,7 +116,13 @@ def run_bluecellulab(
     """
 
     # Get MPI info using NEURON's ParallelContext
-    h.nrn_load_dll(libnrnmech_path)
+    if Path(libnrnmech_path).exists():
+        h.nrn_load_dll(libnrnmech_path)
+    else:
+        logger.info(
+            f"No compiled mechanisms at {libnrnmech_path}; "
+            "using NEURON built-in mechanisms only"
+        )
     h.nrnmpi_init()
     pc = h.ParallelContext()
     rank = int(pc.id())

--- a/app/core/compilation_cache.py
+++ b/app/core/compilation_cache.py
@@ -47,8 +47,13 @@ def compile_with_cache(model_path: Path, mod_dir_name: str) -> None:
         return
 
     mod_dir = model_path / mod_dir_name
-    if not mod_dir.is_dir():
-        raise FileNotFoundError(f"'{mod_dir_name}' folder not found under {model_path}")
+    mod_files = sorted(mod_dir.glob("*.mod")) if mod_dir.is_dir() else []
+    if not mod_files:
+        logger.info(
+            f"No .mod files found under {mod_dir}; skipping compilation "
+            "(model uses only NEURON built-in mechanisms)"
+        )
+        return
 
     mod_hash = compute_mod_hash(mod_dir)
     cache_path = get_compilation_cache_path(mod_hash)

--- a/tests/core/test_compilation_cache.py
+++ b/tests/core/test_compilation_cache.py
@@ -133,12 +133,26 @@ class TestCompileWithCache(unittest.TestCase):
         self.assertEqual(mock_sub.check_output.call_count, 1)  # Still 1
         self.assertTrue((self.model_path / "x86_64" / "lib" / "nrnmech.so").exists())
 
-    def test_missing_mod_dir_raises(self):
-        empty_path = self.tmpdir / "empty"
-        empty_path.mkdir()
+    def test_missing_mod_dir_skips(self):
+        model_path = self.tmpdir / "no_mechanisms"
+        model_path.mkdir()
 
-        with self.assertRaises(FileNotFoundError):
-            compile_with_cache(empty_path, "mechanisms")
+        with patch("app.core.compilation_cache.subprocess") as mock_sub:
+            compile_with_cache(model_path, "mechanisms")
+            mock_sub.check_output.assert_not_called()
+
+        self.assertFalse((model_path / "x86_64").exists())
+
+    def test_empty_mod_dir_skips(self):
+        model_path = self.tmpdir / "empty_mechanisms"
+        model_path.mkdir()
+        (model_path / "mechanisms").mkdir()
+
+        with patch("app.core.compilation_cache.subprocess") as mock_sub:
+            compile_with_cache(model_path, "mechanisms")
+            mock_sub.check_output.assert_not_called()
+
+        self.assertFalse((model_path / "x86_64").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Running a circuit simulation staged from a **passive ME-model** — one that uses only NEURON's built-in mechanisms (e.g. `pas`) and ships **no `.mod` files** — failed with:

```
No .mod files found in <path...>
```

The error surfaced in `compute_mod_hash`, but that's only the first of **three** points in the worker path that assumed every model has custom mechanisms to compile. All three had to tolerate the absence of MOD files for a passive model to run end-to-end.

## Changes

Make "no MOD files" a valid no-op at each point (a passive cell has nothing to compile and nothing custom to load):

1. **`app/core/compilation_cache.py`** — `compile_with_cache` now checks for `.mod` files up front and skips compilation (logs and returns) when there are none, instead of raising. `compute_mod_hash` stays strict and is only reached when files actually exist.
2. **`app/core/circuit/circuit.py`** — `MEModelCircuit._fetch_assets` guards the `mechanisms` → `mod` rename with `if mod_path.is_dir()`, so a passive model with no staged `mechanisms` folder doesn't crash staging.
3. **`app/core/circuit/simulation-mpi-entrypoint.py`** — the MPI entrypoint calls `h.nrn_load_dll(...)` only when the compiled library exists; otherwise it logs and proceeds with built-in mechanisms.

Models that *do* have mechanisms are unaffected — every new branch triggers only when there is genuinely nothing to compile.
