### PR TITLE
Add default values for HOST_UID and HOST_GID in Dockerfile.api

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -40,8 +40,8 @@ EOT
 FROM python:$PYTHON_BASE
 SHELL ["bash", "-e", "-x", "-o", "pipefail", "-c"]
 
-ARG HOST_UID
-ARG HOST_GID
+ARG HOST_UID=1000
+ARG HOST_GID=1000
 
 RUN <<EOT
   groupadd --system --gid ${HOST_GID} --force app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -64,8 +64,8 @@ RUN apt-get update \
   && apt-get install -q -y --no-install-recommends build-essential mpich libmpich-dev libhdf5-dev \
   && rm -rf /var/lib/apt/lists/*
 
-ARG HOST_UID
-ARG HOST_GID
+ARG HOST_UID=1000
+ARG HOST_GID=1000
 
 RUN <<EOT
   groupadd --system --gid ${HOST_GID} --force app

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,8 @@ export IMAGE_TAG_SUFFIX ?= staging
 # endif
 
 # This ensures that owner uid/gid for the volume mounts match the host user.
-ifeq ($(CI),true)
-  UID := 1000
-  GID := 1000
-else
-  UID := $(shell id -u)
-  GID := $(shell id -g)
-endif
+UID := $(shell id -u)
+GID := $(shell id -g)
 
 export UID
 export GID


### PR DESCRIPTION
The new CI workflow uses docker/build-push-action directly instead of docker-compose, which previously passed HOST_UID=${UID} and HOST_GID=${GID} as build args. Without defaults, groupadd receives an empty GID and fails