### PR TITLE
Stop fetching Person for ME-model creators after PlatformUser split

### DIFF
--- a/app/services/api/single_neuron/single_neuron.py
+++ b/app/services/api/single_neuron/single_neuron.py
@@ -30,17 +30,11 @@ from app.utils.rq_job import dispatch
 def _get_or_create_creator_person(client: Client, auth: Auth) -> Person:
     """Resolve a Person agent for the current user without using created_by (now PlatformUser)."""
     token = auth.decoded_token
-    pref_label = token.name or token.preferred_username
-    query: dict[str, str] = {
-        "created_by__id": token.sub,
-        "pref_label": pref_label,
-    }
-    if token.given_name:
-        query["given_name"] = token.given_name
-    if token.family_name:
-        query["family_name"] = token.family_name
-
-    person = client.search_entity(entity_type=Person, limit=1, query=query).first()
+    person = client.search_entity(
+        entity_type=Person,
+        limit=1,
+        query={"created_by__id": token.sub},
+    ).first()
     if person is not None:
         return person
 
@@ -48,7 +42,7 @@ def _get_or_create_creator_person(client: Client, auth: Auth) -> Person:
         Person(
             given_name=token.given_name,
             family_name=token.family_name,
-            pref_label=pref_label,
+            pref_label=token.name or token.preferred_username,
         )
     )
 

--- a/app/services/api/single_neuron/single_neuron.py
+++ b/app/services/api/single_neuron/single_neuron.py
@@ -9,9 +9,6 @@ from entitysdk.models import (
     Strain,
     MTypeClassification,
     ETypeClassification,
-    Person,
-    Role,
-    Contribution,
 )
 from obp_accounting_sdk.constants import ServiceSubtype
 from rq import Queue
@@ -90,19 +87,6 @@ async def create_single_neuron_model(
             )
         )
     )
-
-    created_by = initial_memodel.created_by
-    assert created_by is not None
-    agent_id = created_by.id
-    assert agent_id is not None
-    agent = client.get_entity(entity_id=agent_id, entity_type=Person)
-    role = client.search_entity(entity_type=Role, limit=1, query={"name": "creator role"}).one()
-    contribution = Contribution(
-        agent=agent,
-        role=role,
-        entity=initial_memodel,
-    )
-    contribution = client.register_entity(contribution)
 
     for etype in emodel.etypes or []:
         await run_async(

--- a/app/services/api/single_neuron/single_neuron.py
+++ b/app/services/api/single_neuron/single_neuron.py
@@ -3,8 +3,11 @@ from entitysdk._server_schemas import ValidationStatus
 from entitysdk.models import (
     BrainRegion,
     CellMorphology,
+    Contribution,
     EModel,
     MEModel,
+    Person,
+    Role,
     Species,
     Strain,
     MTypeClassification,
@@ -22,6 +25,32 @@ from app.job import JobFn
 from app.utils.accounting import make_accounting_reservation_async
 from app.utils.asyncio import run_async
 from app.utils.rq_job import dispatch
+
+
+def _get_or_create_creator_person(client: Client, auth: Auth) -> Person:
+    """Resolve a Person agent for the current user without using created_by (now PlatformUser)."""
+    token = auth.decoded_token
+    pref_label = token.name or token.preferred_username
+    query: dict[str, str] = {
+        "created_by__id": token.sub,
+        "pref_label": pref_label,
+    }
+    if token.given_name:
+        query["given_name"] = token.given_name
+    if token.family_name:
+        query["family_name"] = token.family_name
+
+    person = client.search_entity(entity_type=Person, limit=1, query=query).first()
+    if person is not None:
+        return person
+
+    return client.register_entity(
+        Person(
+            given_name=token.given_name,
+            family_name=token.family_name,
+            pref_label=pref_label,
+        )
+    )
 
 
 async def create_single_neuron_model(
@@ -84,6 +113,22 @@ async def create_single_neuron_model(
                 species=species,
                 strain=strain,
                 validation_status=ValidationStatus.created,
+            )
+        )
+    )
+
+    agent = await run_async(lambda: _get_or_create_creator_person(client, auth))
+    role = await run_async(
+        lambda: client.search_entity(
+            entity_type=Role, limit=1, query={"name": "creator role"}
+        ).one()
+    )
+    await run_async(
+        lambda: client.register_entity(
+            Contribution(
+                agent=agent,
+                role=role,
+                entity=initial_memodel,
             )
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = "==3.12.13"
 
 dependencies = [
-    "entitysdk==0.19.8",
+    "entitysdk==0.19.13",
     "loguru==0.7.3",
     "msgpack>=1.2.1",
     "nanoid>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ worker = [
 
 [package.metadata]
 requires-dist = [
-    { name = "entitysdk", specifier = "==0.19.8" },
+    { name = "entitysdk", specifier = "==0.19.13" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -689,14 +689,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.19.8"
+version = "0.19.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/f7/3fcda544cd6f86c0deb1d4442f7f5155971c21a1dd2722e540d108dfc9c6/entitysdk-0.19.8.tar.gz", hash = "sha256:fd5fe5313c0facb144e66f3d9553d1342b91e46f9f38063140fa0632d0b59b4c", size = 92353, upload-time = "2026-07-23T14:05:30.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/bf/b5e0874093cafeb4307e6d1090240226281b62ff4f7e72dda175da64056c/entitysdk-0.19.13.tar.gz", hash = "sha256:68f5c95d94dba5176eeee49afa6fb921de4e3dc33b96a3161870a85b55f74a58", size = 93760, upload-time = "2026-08-12T14:41:06.480Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
## Summary
- EntityCore now stores `created_by` as a `PlatformUser` (Keycloak subject). ME-model creation was looking up that ID as a `Person` agent, which 404s when the user has no Person record.
- Keep the creator `Contribution` link: reuse a `Person` this user already created (`created_by__id` = Keycloak sub), otherwise register one from the token profile, then attach the existing "creator role".
- Bump entitysdk to 0.19.13 so `created_by`/`updated_by` deserialize as `PlatformUser`.

## Test plan
- [ ] Create a single-neuron ME-model as a user who has a PlatformUser but no Person agent (the previous failure case)
- [ ] Confirm a Person is created (or reused) and the ME-model has a creator contribution
- [ ] Create a second ME-model as the same user (including in another project) and confirm the same Person is reused
- [ ] Confirm calibration/validation jobs still dispatch after create