### PR TITLE
Search agent by sub_id for contribution

### DIFF
--- a/app/services/api/single_neuron/single_neuron.py
+++ b/app/services/api/single_neuron/single_neuron.py
@@ -3,15 +3,15 @@ from entitysdk._server_schemas import ValidationStatus
 from entitysdk.models import (
     BrainRegion,
     CellMorphology,
+    Contribution,
     EModel,
-    MEModel,
-    Species,
-    Strain,
-    MTypeClassification,
     ETypeClassification,
+    MEModel,
+    MTypeClassification,
     Person,
     Role,
-    Contribution,
+    Species,
+    Strain,
 )
 from obp_accounting_sdk.constants import ServiceSubtype
 from rq import Queue
@@ -91,18 +91,25 @@ async def create_single_neuron_model(
         )
     )
 
-    created_by = initial_memodel.created_by
-    assert created_by is not None
-    agent_id = created_by.id
-    assert agent_id is not None
-    agent = client.get_entity(entity_id=agent_id, entity_type=Person)
-    role = client.search_entity(entity_type=Role, limit=1, query={"name": "creator role"}).one()
-    contribution = Contribution(
-        agent=agent,
-        role=role,
-        entity=initial_memodel,
+    agent = await run_async(
+        lambda: client.search_entity(
+            entity_type=Person, limit=1, query={"sub_id": initial_memodel.created_by.id}
+        ).one()
     )
-    contribution = client.register_entity(contribution)
+    role = await run_async(
+        lambda: client.search_entity(
+            entity_type=Role, limit=1, query={"name": "creator role"}
+        ).one()
+    )
+    await run_async(
+        lambda: client.register_entity(
+            Contribution(
+                agent=agent,
+                role=role,
+                entity=initial_memodel,
+            )
+        )
+    )
 
     for etype in emodel.etypes or []:
         await run_async(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = "==3.12.13"
 
 dependencies = [
-    "entitysdk==0.19.8",
+    "entitysdk==0.19.14",
     "loguru==0.7.3",
     "msgpack>=1.2.1",
     "nanoid>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ worker = [
 
 [package.metadata]
 requires-dist = [
-    { name = "entitysdk", specifier = "==0.19.8" },
+    { name = "entitysdk", specifier = "==0.19.14" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "nanoid", specifier = ">=2.0.0" },
@@ -689,14 +689,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.19.8"
+version = "0.19.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/f7/3fcda544cd6f86c0deb1d4442f7f5155971c21a1dd2722e540d108dfc9c6/entitysdk-0.19.8.tar.gz", hash = "sha256:fd5fe5313c0facb144e66f3d9553d1342b91e46f9f38063140fa0632d0b59b4c", size = 92353, upload-time = "2026-07-23T14:05:30.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/b5/f8909e412a2454d29ffa5ba0e1c1e4a98dd4621f1aae86df99e9e79e29f2/entitysdk-0.19.14.tar.gz", hash = "sha256:e9486123b0be8e40426b776284189b5975a82df8b81404cec365ca7873455b51", size = 93790, upload-time = "2026-08-14T14:22:16.367Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
Retrieve the agent by `sub_id`, instead of using directly `initial_memodel.created_by.id`.

The fix is needed only in app/services/api/single_neuron/single_neuron.py, since it's the only function where a Person is retrieved to register a contribution.

- Needed for the changes in https://github.com/openbraininstitute/entitycore/pull/686 (deployed to staging, not deployed to production yet)
- Requires the changes in https://github.com/openbraininstitute/entitycore/pull/704 and entitycore 2026.8.6 (not release yet)
- Supersedes: https://github.com/openbraininstitute/Bluenaas/pull/169
- Unrelated fix: wraps remaining sync entitysdk calls with run_async.

## Test plan
- [ ] Create a single-neuron ME-model as a user who has a PlatformUser but no Person agent (the previous failure case)
- [ ] Confirm a Person is created (or reused) and the ME-model has a creator contribution
- [ ] Create a second ME-model as the same user (including in another project) and confirm the same Person is reused
- [ ] Confirm calibration/validation jobs still dispatch after create